### PR TITLE
Fix typo in page title

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -30,7 +30,7 @@ export default function Home() {
   return (
     <Layout
       title={`REST API PHP Components`}
-      description="A modern set of PHP components to build type-save APIs">
+      description="A modern set of PHP components to build type-safe APIs">
       <HomepageHeader />
       <main>
         <HomepageFeatures />


### PR DESCRIPTION
It may require initiating a build for regenerate `index.html`, but I can't do this from GitHub UI :(